### PR TITLE
GS-5318 Allowed scopes vs Requested Scopes for ExtrnalClients

### DIFF
--- a/source/Core/Validation/AuthorizeRequestValidator.cs
+++ b/source/Core/Validation/AuthorizeRequestValidator.cs
@@ -101,8 +101,7 @@ namespace IdentityServer3.Core.Validation
                         .ToList();
                 }
 
-                var scopeToValidate = request.Client.AllowedScopes.Union(requestedScopes).Distinct().ToList();
-                var validScopes = (await _scopeValidator.GetValidScopesForExternalClientAsync(scopeToValidate, request.Client.Flow, request.ResponseType)).ToList();
+                var validScopes = (await _scopeValidator.GetValidScopesForExternalClientAsync(requestedScopes, request.Client.Flow, request.ResponseType)).ToList();
 
                 var clientScope = string.Join(" ", validScopes);
 

--- a/source/Core/Validation/AuthorizeRequestValidator.cs
+++ b/source/Core/Validation/AuthorizeRequestValidator.cs
@@ -88,27 +88,6 @@ namespace IdentityServer3.Core.Validation
                 return mandatoryResult;
             }
 
-            if (request.Client.Claims.Any(c => c.Type == Constants.ClaimTypes.ExternalProviderClient && c.Value == bool.TrueString))
-            {
-                var rawRequestedScopes = parameters.Get(Constants.TokenRequest.Scope);
-                var requestedScopes = new List<string>();
-
-                if (!string.IsNullOrWhiteSpace(rawRequestedScopes))
-                {
-                    requestedScopes = rawRequestedScopes.Trim()
-                        .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
-                        .Distinct()
-                        .ToList();
-                }
-
-                var validScopes = (await _scopeValidator.GetValidScopesForExternalClientAsync(requestedScopes, request.Client.Flow, request.ResponseType)).ToList();
-
-                var clientScope = string.Join(" ", validScopes);
-
-                parameters.Remove(Constants.TokenRequest.Scope);
-                parameters.Add(Constants.TokenRequest.Scope, clientScope);
-            }
-
             // scope, scope restrictions and plausability
             var scopeResult = await ValidateScopeAsync(request);
             if (scopeResult.IsError)

--- a/source/Core/Validation/ScopeValidator.cs
+++ b/source/Core/Validation/ScopeValidator.cs
@@ -77,37 +77,6 @@ namespace IdentityServer3.Core.Validation
             GrantedScopes.RemoveAll(scope => !scope.Required && !consentedScopes.Contains(scope.Name));
         }
 
-        internal async Task<IEnumerable<string>> GetValidScopesForExternalClientAsync(IEnumerable<string> requestedScopes, Flows clientFlow, string responseType = null)
-        {
-            if (requestedScopes == null || !requestedScopes.Any())
-                return Enumerable.Empty<string>();
-
-            var availableScopes = await _store.FindScopesAsync(requestedScopes);
-
-            if (clientFlow == Flows.ClientCredentials)
-            {
-                return availableScopes.Where(s => s.Type == ScopeType.Resource && s.Enabled).Select(s => s.Name);
-            }
-
-            var requirement = Constants.ResponseTypeToScopeRequirement[responseType];
-
-            if (requirement == Constants.ScopeRequirement.ResourceOnly)
-            {
-                return availableScopes.Where(s => s.Type == ScopeType.Resource && s.Enabled).Select(s => s.Name);
-            }
-            if (requirement == Constants.ScopeRequirement.IdentityOnly)
-            {
-                return availableScopes.Where(s => s.Type == ScopeType.Identity && s.Enabled).Select(s => s.Name);
-            }
-
-            if (requirement == Constants.ScopeRequirement.Identity)
-            {
-                return availableScopes.Where(s =>s.Enabled).Select(s => s.Name);
-            }
-
-            return availableScopes.Where(s => s.Enabled).Select(s => s.Name);
-        }
-
         public async Task<bool> AreScopesValidAsync(IEnumerable<string> requestedScopes)
         {
             var availableScopes = await _store.FindScopesAsync(requestedScopes);

--- a/source/Core/Validation/TokenRequestValidator.cs
+++ b/source/Core/Validation/TokenRequestValidator.cs
@@ -98,9 +98,8 @@ namespace IdentityServer3.Core.Validation
                 }
 
                 var validScopes = (await _scopeValidator.GetValidScopesForExternalClientAsync(requestedScopes, client.Flow)).ToList();
-                var allowedScope = client.AllowedScopes.Union(validScopes).Distinct().ToList();
 
-                var clientScope = string.Join(" ", allowedScope);
+                var clientScope = string.Join(" ", validScopes);
 
                 parameters.Remove(Constants.TokenRequest.Scope);
                 parameters.Add(Constants.TokenRequest.Scope, clientScope);

--- a/source/Core/Validation/TokenRequestValidator.cs
+++ b/source/Core/Validation/TokenRequestValidator.cs
@@ -84,27 +84,6 @@ namespace IdentityServer3.Core.Validation
                 throw new ArgumentNullException("parameters");
             }
 
-            if (client.Claims.Any(c => c.Type == Constants.ClaimTypes.ExternalProviderClient && c.Value == bool.TrueString))
-            {
-                var rawRequestedScopes = parameters.Get(Constants.TokenRequest.Scope);
-                var requestedScopes = new List<string>();
-
-                if (!string.IsNullOrWhiteSpace(rawRequestedScopes))
-                {
-                    requestedScopes = rawRequestedScopes.Trim()
-                        .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
-                        .Distinct()
-                        .ToList();
-                }
-
-                var validScopes = (await _scopeValidator.GetValidScopesForExternalClientAsync(requestedScopes, client.Flow)).ToList();
-
-                var clientScope = string.Join(" ", validScopes);
-
-                parameters.Remove(Constants.TokenRequest.Scope);
-                parameters.Add(Constants.TokenRequest.Scope, clientScope);
-            }
-
             _validatedRequest.Raw = parameters;
             _validatedRequest.Client = client;
             _validatedRequest.Options = _options;


### PR DESCRIPTION
Though External Clients are allowed some additional scopes by default (besides those in database), they should only be granted access to what is requested.