### PR TITLE
GS-8142 Do not over write an existing valid cookie due to amr value being set

### DIFF
--- a/source/Core/Constants.cs
+++ b/source/Core/Constants.cs
@@ -730,7 +730,7 @@ namespace IdentityServer3.Core
         {
             public const string Certificate             = "certificate";
             public const string Password                = "password";
-            public const string TwoFactorAuthentication = "2fa";
+            public const string MultiFactorAuthentication = "mfa";
             public const string Passwordless = "passwordless";
             public const string External                = "external";
         }

--- a/source/Core/Endpoints/AuthenticationController.cs
+++ b/source/Core/Endpoints/AuthenticationController.cs
@@ -863,7 +863,7 @@ namespace IdentityServer3.Core.Endpoints
                 sessionCookie.IssueSessionId(rememberMe);
 
                 var twoFactorAmr = id.FindFirst(c => c.Type == Constants.ClaimTypes.AuthenticationMethod);
-                if (twoFactorAmr != null && twoFactorAmr.Value == Constants.AuthenticationMethods.TwoFactorAuthentication)
+                if (twoFactorAmr != null && twoFactorAmr.Value == Constants.AuthenticationMethods.TwoFactorAuthentication && !twoFactorCookie.IsValid(authResult.User.GetSubjectId()))
                 {
                     var twoFactorAmrRemember = id.FindFirst(c => c.Type == Constants.ClaimTypes.TwoFactorRememberDevice);
                     var remember = twoFactorAmrRemember != null && bool.Parse(twoFactorAmrRemember.Value);

--- a/source/Core/Endpoints/AuthenticationController.cs
+++ b/source/Core/Endpoints/AuthenticationController.cs
@@ -863,7 +863,7 @@ namespace IdentityServer3.Core.Endpoints
                 sessionCookie.IssueSessionId(rememberMe);
 
                 var twoFactorAmr = id.FindFirst(c => c.Type == Constants.ClaimTypes.AuthenticationMethod);
-                if (twoFactorAmr != null && twoFactorAmr.Value == Constants.AuthenticationMethods.TwoFactorAuthentication && !twoFactorCookie.IsValid(authResult.User.GetSubjectId()))
+                if (twoFactorAmr != null && twoFactorAmr.Value == Constants.AuthenticationMethods.MultiFactorAuthentication && !twoFactorCookie.IsValid(authResult.User.GetSubjectId()))
                 {
                     var twoFactorAmrRemember = id.FindFirst(c => c.Type == Constants.ClaimTypes.TwoFactorRememberDevice);
                     var remember = twoFactorAmrRemember != null && bool.Parse(twoFactorAmrRemember.Value);

--- a/source/Core/Validation/AuthorizeRequestValidator.cs
+++ b/source/Core/Validation/AuthorizeRequestValidator.cs
@@ -546,7 +546,7 @@ namespace IdentityServer3.Core.Validation
             }
 
             if (request.Subject.Identity.IsAuthenticated && 
-            request.Subject.Claims.Any(c => c.Type == Constants.ClaimTypes.AuthenticationMethod && c.Value == Constants.AuthenticationMethods.TwoFactorAuthentication))
+            request.Subject.Claims.Any(c => c.Type == Constants.ClaimTypes.AuthenticationMethod && c.Value == Constants.AuthenticationMethods.MultiFactorAuthentication))
             {
                 if (!_twoFactorCookie.IsValid(request.Subject.GetSubjectId()))
                 {


### PR DESCRIPTION
If there is an existing valid cookie, we would not prompt user for 2fa. We just need to set the amr value. We should not issue a new cookie as existing cookie may expire longer (remember me option).

This may need to be changed however if in future, we ever need to support twofactor-challange option with which the user will be prompted even if an existing cookie is there. In that scenrio, the new cookie should be set with expiry as per user options.